### PR TITLE
make sure to patch executable too

### DIFF
--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -4,13 +4,35 @@ from pathlib import Path
 
 from venvception import venv
 
+
 def test_subprocess_uses_venv_python():
     with venv(Path("tests/fixtures/requirements.txt")) as venv_path:
         # Execute Python within the subprocess to print its executable path
-        output = subprocess.check_output([str(venv_path / 'bin' / 'python'), '-c', 'import sys; print(sys.executable)'], text=True)
+        output = subprocess.check_output(
+            [str(venv_path / "bin" / "python"), "-c", "import sys; print(sys.executable)"],
+            text=True,
+        )
 
         # Verify that the subprocess uses the Python interpreter from the virtual environment
-        assert str(venv_path / 'bin' / 'python') in output.strip()
+        assert str(venv_path / "bin" / "python") in output.strip()
+
+
+def test_nested_inception_subprocess_uses_venv_python():
+    with venv(Path("tests/fixtures/requirements.txt"), "outer"):
+        with venv(Path("tests/fixtures/requirements.txt"), "inner") as venv_path_inner:
+            # Execute Python within the subprocess to print its executable path
+            output = subprocess.check_output(
+                [
+                    str(venv_path_inner / "bin" / "python"),
+                    "-c",
+                    "import sys; print(sys.executable)",
+                ],
+                text=True,
+            )
+
+            # Verify that the subprocess uses the Python interpreter from the virtual environment
+            assert str(venv_path_inner / "bin" / "python") in output.strip()
+
 
 def test_venv_assumption():
     with venv(Path("tests/fixtures/requirements.txt")) as venv_path:
@@ -20,10 +42,11 @@ def test_venv_assumption():
         # Verify that it is being installed from the virtual environment we created
         assert Path(ulid.__file__).relative_to(venv_path)
 
+
 def test_environment_reverted_after_context():
-    original_path = os.environ['PATH']
+    original_path = os.environ["PATH"]
     with venv(Path("tests/fixtures/requirements.txt")):
         pass  # Just enter and exit the context
 
     # Verify that the PATH environment variable is reverted to its original value after exiting the context
-    assert os.environ['PATH'] == original_path
+    assert os.environ["PATH"] == original_path

--- a/venvception/venv.py
+++ b/venvception/venv.py
@@ -38,15 +38,15 @@ def venv(requirements_file: Path, env_id: Optional[str] = None):
 
         pip_install(env_path, requirements_file)
 
-        bin_dir = 'Scripts' if os.name == 'nt' else 'bin'
+        bin_dir = "Scripts" if os.name == "nt" else "bin"
         venv_bin_path = str(env_path / bin_dir)
 
-        original_path = os.environ.get('PATH', '')
+        original_path = os.environ.get("PATH", "")
         # Subprocess (forked process) updates
-        os.environ['PATH'] = f"{venv_bin_path}{os.pathsep}{original_path}"
+        os.environ["PATH"] = f"{venv_bin_path}{os.pathsep}{original_path}"
 
         original_executable = sys.executable
-        sys.executable = os.path.join(venv_bin_path, 'python')
+        sys.executable = os.path.join(venv_bin_path, "python")
 
         # Current process updates
         original_sys_path = list(sys.path)
@@ -70,7 +70,7 @@ def venv(requirements_file: Path, env_id: Optional[str] = None):
             yield env_path
         finally:
             # We update path with the site module but attempt to restore it via sys
-            os.environ['PATH'] = original_path
+            os.environ["PATH"] = original_path
             sys.path[:] = original_sys_path
             sys.executable = original_executable
 

--- a/venvception/venv.py
+++ b/venvception/venv.py
@@ -46,7 +46,7 @@ def venv(requirements_file: Path, env_id: Optional[str] = None):
         os.environ['PATH'] = f"{venv_bin_path}{os.pathsep}{original_path}"
 
         original_executable = sys.executable
-        sys.executable = str(venv_bin_path / 'python')
+        sys.executable = os.path.join(venv_bin_path, 'python')
 
         # Current process updates
         original_sys_path = list(sys.path)

--- a/venvception/venv.py
+++ b/venvception/venv.py
@@ -45,6 +45,9 @@ def venv(requirements_file: Path, env_id: Optional[str] = None):
         # Subprocess (forked process) updates
         os.environ['PATH'] = f"{venv_bin_path}{os.pathsep}{original_path}"
 
+        original_executable = sys.executable
+        sys.executable = str(venv_bin_path / 'python')
+
         # Current process updates
         original_sys_path = list(sys.path)
         site_packages_path = env_path / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}" / "site-packages"
@@ -69,6 +72,7 @@ def venv(requirements_file: Path, env_id: Optional[str] = None):
             # We update path with the site module but attempt to restore it via sys
             os.environ['PATH'] = original_path
             sys.path[:] = original_sys_path
+            sys.executable = original_executable
 
 
 def hash_file_id(filepath: Path) -> str:


### PR DESCRIPTION
### Problem

`apache-beam` still sniffs the parent venv executable 

### Fix

* so patch it like everything else b/c this is venvception 🪄  
* added another "nested" test even though you had a test to cover it
* ran `black` on tests b/c I'm a total dick